### PR TITLE
feature : Add User service join

### DIFF
--- a/src/main/java/com/example/medium_clone/application/user/UserRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/UserRestController.java
@@ -1,17 +1,29 @@
 package com.example.medium_clone.application.user;
 
 import com.example.medium_clone.application.user.dto.UserRegisterDto;
+import com.example.medium_clone.application.user.entity.User;
+import com.example.medium_clone.application.user.repository.UserRepository;
+import com.example.medium_clone.application.user.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.persistence.NoResultException;
+import java.util.Optional;
+
 @RestController()
+@RequiredArgsConstructor
 @RequestMapping("/api/users")
 public class UserRestController {
 
+    private final UserService userService;
+    private final UserRepository userRepository;
+
     @PostMapping("/register")
-    public UserRegisterDto registerUser(@RequestBody UserRegisterDto dto) {
-        return dto;
+    public User registerUser(@RequestBody UserRegisterDto dto) {
+        Long memberId = userService.join(dto);
+        return userRepository.findById(memberId).orElseThrow(NoResultException::new);
     }
 }

--- a/src/main/java/com/example/medium_clone/application/user/entity/User.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/User.java
@@ -16,7 +16,7 @@ public class User {
     private String password;
     private String email;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "profile_id")
     private Profile profile;
 

--- a/src/main/java/com/example/medium_clone/application/user/service/UserService.java
+++ b/src/main/java/com/example/medium_clone/application/user/service/UserService.java
@@ -1,0 +1,32 @@
+     package com.example.medium_clone.application.user.service;
+
+import com.example.medium_clone.application.user.dto.UserRegisterDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.entity.User;
+import com.example.medium_clone.application.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+// Default transaction mode is read only.
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long join(UserRegisterDto registerDto) {
+        Profile profile = Profile.createProfile("", registerDto.getUsername());
+
+        User user = User.createUser(
+                    registerDto.getPassword(),
+                    registerDto.getEmail(),
+                    profile
+                );
+
+        userRepository.save(user);
+        return user.getId();
+    }
+}

--- a/src/main/java/com/example/medium_clone/application/user/service/UserService.java
+++ b/src/main/java/com/example/medium_clone/application/user/service/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
                     profile
                 );
 
-        userRepository.save(user);
-        return user.getId();
+        User savedUser = userRepository.save(user);
+        return savedUser.getId();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,13 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+      format_sql: true
+    database-platform: org.hibernate.dialect.H2Dialect

--- a/src/test/java/com/example/medium_clone/application/user/entity/ProfileTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/entity/ProfileTest.java
@@ -1,0 +1,24 @@
+package com.example.medium_clone.application.user.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfileTest {
+
+    @Test
+    public void testCreateProfile() {
+        // given
+        String bio = "";
+        String username = "name";
+
+        // when
+        Profile createdProfile = Profile.createProfile(bio, username);
+
+        // then
+        Assertions.assertThat(createdProfile.getBio()).isEqualTo(bio);
+        Assertions.assertThat(createdProfile.getUsername()).isEqualTo(username);
+    }
+
+}

--- a/src/test/java/com/example/medium_clone/application/user/entity/UserTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/entity/UserTest.java
@@ -1,0 +1,24 @@
+package com.example.medium_clone.application.user.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class UserTest {
+
+    @Test
+    public void testCreateUser() {
+        // given
+        String password = "password";
+        String email = "name@test.com";
+        Profile profile = mock(Profile.class);
+
+        // when
+        User createdUser = User.createUser(password, email, profile);
+
+        // then
+        assertThat(createdUser.getPassword()).isEqualTo(password);
+        assertThat(createdUser.getEmail()).isEqualTo(email);
+    }
+}

--- a/src/test/java/com/example/medium_clone/application/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/service/UserServiceTest.java
@@ -1,0 +1,53 @@
+package com.example.medium_clone.application.user.service;
+
+import com.example.medium_clone.application.user.dto.UserRegisterDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.entity.User;
+import com.example.medium_clone.application.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    public void testJoin() {
+        // given
+        UserRegisterDto dto = new UserRegisterDto();
+        dto.setUsername("name");
+        dto.setPassword("password");
+        dto.setEmail("name@test.com");
+
+        User user = mock(User.class);
+        Long fakeId = 1L;
+
+        // mocking
+        when(user.getId()).thenReturn(fakeId);
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        // when
+        Long joinId = userService.join(dto);
+
+        // then
+        Assertions.assertThat(joinId).isEqualTo(fakeId);
+    }
+}


### PR DESCRIPTION
## 목적
- User 서비스에 회원 가입 로직을 구현해 컨트롤러에서 이용할 수 있도록 합니다.

## 변경 사항
- UserRestController
  - UserService를 이용해 실제로 회원을 저장합니다.
- UserService에 join 추가
  - 회원 가입 로직에서 profile 생성 후 user도 생성해 저장합니다.
- 테스트
  - User
    - 생성 
  - Profile
    - 생성 
  - UserService
    - 회원 가입  
- application.yml
  - jpa.hibernate 설정 추가 

## 버그 픽스
- User
  - `profile`에 `cascade` 설정을 안 해서  user 저장 시 오류가 나던 것을 수정했습니다.