### PR TITLE
hotfix: Fix update profile

### DIFF
--- a/src/main/java/com/example/medium_clone/application/user/ProfileRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/ProfileRestController.java
@@ -1,9 +1,10 @@
 package com.example.medium_clone.application.user;
 
-import com.example.medium_clone.application.user.dto.ProfileDto;
+import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.NoSuchElementException;
@@ -21,10 +22,7 @@ public class ProfileRestController {
     }
 
     @PatchMapping("/{username}")
-    public ProfileDto updateProfile(@PathVariable String username) {
-        ProfileDto dto = new ProfileDto();
-        dto.setUsername("demo");
-        dto.setBio("demo");
-        return dto;
+    public ResponseEntity<Profile> updateProfile(@PathVariable String username, @RequestBody ProfileUpdateDto dto) {
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/medium_clone/application/user/dto/ProfileUpdateDto.java
+++ b/src/main/java/com/example/medium_clone/application/user/dto/ProfileUpdateDto.java
@@ -3,7 +3,7 @@ package com.example.medium_clone.application.user.dto;
 import lombok.Data;
 
 @Data
-public class ProfileDto {
+public class ProfileUpdateDto {
 
     private String username;
     private String bio;


### PR DESCRIPTION
## 목적
- PATCH 요청에서 리퀘스트 바디를 통해 업데이트 요청을 할 수 없던 걸 수정합니다.

## 변경 사항
- ProfileDto -> ProfileUpdateDto
  - 업데이트 요청에 사용하는 DTO인데 네이밍이 불분명해 수정했습니다. 
- ProfileRestController::updateProfile
  - 리퀘스트 바디를 받지 않던 걸 수정했습니다.
  - DTO를 리턴하지 않고 204 no cotent만 반환하도록 수정했습니다. 