### PR TITLE
hotfix: Handle profile 404

### DIFF
--- a/src/main/java/com/example/medium_clone/application/user/controller/ProfileNotFoundAdvice.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/ProfileNotFoundAdvice.java
@@ -1,0 +1,19 @@
+package com.example.medium_clone.application.user.controller;
+
+import com.example.medium_clone.application.user.exception.ProfileNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class ProfileNotFoundAdvice {
+
+    @ResponseBody
+    @ExceptionHandler(ProfileNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    String profileNotFoundHandler(ProfileNotFoundException exception) {
+        return exception.getMessage();
+    }
+}

--- a/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
@@ -1,9 +1,10 @@
-package com.example.medium_clone.application.user;
+package com.example.medium_clone.application.user.controller;
 
 import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
@@ -2,13 +2,11 @@ package com.example.medium_clone.application.user.controller;
 
 import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
 import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.exception.ProfileNotFoundException;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.NoSuchElementException;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,7 +17,7 @@ public class ProfileRestController {
 
     @GetMapping("/{username}")
     public Profile getProfile(@PathVariable String username) {
-        return profileRepository.findByUsername(username).orElseThrow(NoSuchElementException::new);
+        return profileRepository.findByUsername(username).orElseThrow(() -> new ProfileNotFoundException(username));
     }
 
     @PatchMapping("/{username}")

--- a/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
@@ -1,4 +1,4 @@
-package com.example.medium_clone.application.user;
+package com.example.medium_clone.application.user.controller;
 
 import com.example.medium_clone.application.user.dto.UserRegisterDto;
 import com.example.medium_clone.application.user.entity.User;

--- a/src/main/java/com/example/medium_clone/application/user/exception/ProfileNotFoundException.java
+++ b/src/main/java/com/example/medium_clone/application/user/exception/ProfileNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.medium_clone.application.user.exception;
+
+import java.util.NoSuchElementException;
+
+public class ProfileNotFoundException extends NoSuchElementException {
+
+    public ProfileNotFoundException(String username) {
+        super(username + " profile not found.");
+    }
+}


### PR DESCRIPTION
## 목적
- 존재하지 않는 프로필을 조회했을 때 에러로 해당 프로필이 없는 것을 알려줍니다.

## 관련 이슈
Close #12 

## 변경사항
- ProfileRestController
  - username으로 프로필을 조회했을 때 , 해당 결과가 없다면 ProfileNotFoundException을 발생시킵니다.
- ProfileNotFoundException 추가 
- ProfileNotFoundAdvice
  -  ProfileNotFoundException 핸들러 추가
