### PR TITLE
feature: Add controller test

### DIFF
--- a/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
@@ -1,0 +1,55 @@
+package com.example.medium_clone.application.user.controller;
+
+import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.repository.ProfileRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProfileRestController.class)
+class ProfileRestControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean ProfileRepository profileRepository;
+    private final String commonPath = "/api/profiles";
+
+    @Test
+    public void testGetProfileOk() throws Exception {
+        String username = setTestUserProfile();
+
+        // then
+        mockMvc.perform(get(commonPath + "/" + username))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testGetProfileNotFound() throws Exception {
+        mockMvc.perform(get(commonPath + "/" + "notFound"))
+                .andExpect(status().isNotFound());
+    }
+
+    private String setTestUserProfile() {
+        // given
+        String username = "test";
+        String bio = "";
+
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setUsername(username);
+
+        Profile profile = Profile.createProfile(bio, username);
+
+        // mocking
+        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(profile));
+
+        return username;
+    }
+}

--- a/src/test/java/com/example/medium_clone/application/user/controller/UserRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/controller/UserRestControllerTest.java
@@ -1,0 +1,62 @@
+package com.example.medium_clone.application.user.controller;
+
+import com.example.medium_clone.application.user.dto.UserRegisterDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.entity.User;
+import com.example.medium_clone.application.user.repository.UserRepository;
+import com.example.medium_clone.application.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserRestController.class)
+class UserRestControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockBean UserService userService;
+    @MockBean UserRepository userRepository;
+    private final String commonPath = "/api/users";
+
+    @Test
+    public void testRegisterUser() throws Exception {
+        // given
+        String username = "test";
+        String password = "password";
+        String email = "test@email.com";
+        String bio = "";
+
+        UserRegisterDto dto = new UserRegisterDto();
+        dto.setUsername(username);
+        dto.setPassword(password);
+        dto.setEmail(email);
+        String body = objectMapper.writeValueAsString(dto);
+
+        Profile profile = Profile.createProfile(bio, username);
+        User user = User.createUser(password, email, profile);
+        Long fakeId = 1L;
+
+        // mocking
+        when(userService.join(any(UserRegisterDto.class))).thenReturn(fakeId);
+        when(userRepository.findById(fakeId)).thenReturn(Optional.of(user));
+
+        // then
+        mockMvc.perform(post(commonPath + "/register")
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+    }
+
+}


### PR DESCRIPTION
## 목적
- 유저 등록, 프로필 조회에 대한 테스트를 수행해 문제가 있는지 확인합니다.

## 관련 이슈
Close #11 

## 변경사항
- UserRestControllerTest
  - 유저 등록 요청인 `POST /api/users` 테스트
    - 유저가 정상적으로 등록되는지 확인 
- ProfileRestControllerTest
  - 프로필 조회 요청인 `GET /api/profiles/{username}` 테스트
    - 200 OK: 저장된 유저에 대해 조회했을 때 제대로 조회가 되는지 확인
    - 404 Not Found: 저장되지 않은 유저에 대해 조회했을 때 404가 나오는지 확인 

## 참고
- https://shinsunyoung.tistory.com/52
- https://spring.io/guides/gs/testing-web/
