### PR TITLE
feature: Add timestamp to entity.

### DIFF
--- a/src/main/java/com/example/medium_clone/MediumCloneApplication.java
+++ b/src/main/java/com/example/medium_clone/MediumCloneApplication.java
@@ -2,7 +2,9 @@ package com.example.medium_clone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MediumCloneApplication {
 

--- a/src/main/java/com/example/medium_clone/application/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/medium_clone/application/common/entity/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.example.medium_clone.application.common.entity;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
@@ -1,5 +1,6 @@
 package com.example.medium_clone.application.user.entity;
 
+import com.example.medium_clone.application.common.entity.BaseTimeEntity;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -11,7 +12,7 @@ import javax.persistence.Id;
 @Entity
 @Getter
 @ToString(of = {"id", "username"})
-public class Profile {
+public class Profile extends BaseTimeEntity {
 
     @Id @GeneratedValue
     @Column(name = "profile_id")

--- a/src/main/java/com/example/medium_clone/application/user/entity/User.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.medium_clone.application.user.entity;
 
+import com.example.medium_clone.application.common.entity.BaseTimeEntity;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -8,7 +9,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @ToString(of = {"id", "email"})
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id @GeneratedValue
     @Column(name = "user_id")


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- 유저와 프로필 엔티티에 생성일과 수정일을 추가해 변경 기록을 추적할 수 있도록 합니다.

## 관련 이슈
Close #19

## 변경사항
- `BaseTimeEntity`를 추가하고 `User`, `Profile`에서 확장
- `@EnableJpaAuditing`를 main에 추가

## 참고
- https://www.baeldung.com/jpa-entity-lifecycle-events
