### PR TITLE
hotfix : Fix JPA metamodel error in test.

### DIFF
--- a/src/main/java/com/example/medium_clone/JpaAuditingConfig.java
+++ b/src/main/java/com/example/medium_clone/JpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package com.example.medium_clone;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {}

--- a/src/main/java/com/example/medium_clone/MediumCloneApplication.java
+++ b/src/main/java/com/example/medium_clone/MediumCloneApplication.java
@@ -2,9 +2,7 @@ package com.example.medium_clone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class MediumCloneApplication {
 


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- 컨트롤러 테스트를 수행할 때 JPA Auditing 때문에 에러가 나던 것을 해결합니다.

## 변경사항
- 메인 함수에서 `@EnableJpaAuditing`을 제거
- `JpaAuditingConfig`를 만들어 해당 클래스에 `@EnableJpaAuditing`을 추가

## 참고
- https://1-7171771.tistory.com/136
