### PR TITLE
feature: Add update Profile

### DIFF
--- a/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
@@ -4,6 +4,7 @@ import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.exception.ProfileNotFoundException;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
+import com.example.medium_clone.application.user.service.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/profiles")
 public class ProfileRestController {
 
+    private final ProfileService profileService;
     private final ProfileRepository profileRepository;
 
     @GetMapping("/{username}")
@@ -22,6 +24,7 @@ public class ProfileRestController {
 
     @PatchMapping("/{username}")
     public ResponseEntity<Profile> updateProfile(@PathVariable String username, @RequestBody ProfileUpdateDto dto) {
+        profileService.update(username, dto);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/medium_clone/application/user/dto/ProfileUpdateDto.java
+++ b/src/main/java/com/example/medium_clone/application/user/dto/ProfileUpdateDto.java
@@ -2,10 +2,21 @@ package com.example.medium_clone.application.user.dto;
 
 import lombok.Data;
 
+import java.util.Optional;
+
 @Data
 public class ProfileUpdateDto {
 
     private String username;
     private String bio;
 
+    // Getter 반환 타입을 Optional로 표시해, request body에 명시되지 않을 수도 있는 것을 나타낸다.
+
+    public Optional<String> getUsername() {
+        return Optional.ofNullable(username);
+    }
+
+    public Optional<String> getBio() {
+        return Optional.ofNullable(bio);
+    }
 }

--- a/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
@@ -27,4 +27,12 @@ public class Profile extends BaseTimeEntity {
 
         return profile;
     }
+
+    public void changeBio(String bio) {
+        this.bio = bio;
+    }
+
+    public void changeUsername(String username) {
+        this.username = username;
+    }
 }

--- a/src/main/java/com/example/medium_clone/application/user/service/ProfileService.java
+++ b/src/main/java/com/example/medium_clone/application/user/service/ProfileService.java
@@ -17,12 +17,14 @@ public class ProfileService {
     private final ProfileRepository profileRepository;
 
     @Transactional
-    public void update(String username, ProfileUpdateDto dto) {
+    public Long update(String username, ProfileUpdateDto dto) {
         Profile profile = profileRepository.findByUsername(username).orElseThrow(
                 () -> new ProfileNotFoundException(username)
         );
 
         dto.getUsername().ifPresent(profile::changeUsername);
         dto.getBio().ifPresent(profile::changeBio);
+
+        return profile.getId();
     }
 }

--- a/src/main/java/com/example/medium_clone/application/user/service/ProfileService.java
+++ b/src/main/java/com/example/medium_clone/application/user/service/ProfileService.java
@@ -1,0 +1,16 @@
+package com.example.medium_clone.application.user.service;
+
+import com.example.medium_clone.application.user.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+// Default transaction mode is read only.
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final ProfileRepository profileRepository;
+
+}

--- a/src/main/java/com/example/medium_clone/application/user/service/ProfileService.java
+++ b/src/main/java/com/example/medium_clone/application/user/service/ProfileService.java
@@ -1,5 +1,8 @@
 package com.example.medium_clone.application.user.service;
 
+import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.exception.ProfileNotFoundException;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,4 +16,13 @@ public class ProfileService {
 
     private final ProfileRepository profileRepository;
 
+    @Transactional
+    public void update(String username, ProfileUpdateDto dto) {
+        Profile profile = profileRepository.findByUsername(username).orElseThrow(
+                () -> new ProfileNotFoundException(username)
+        );
+
+        dto.getUsername().ifPresent(profile::changeUsername);
+        dto.getBio().ifPresent(profile::changeBio);
+    }
 }

--- a/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
@@ -3,22 +3,29 @@ package com.example.medium_clone.application.user.controller;
 import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
+import com.example.medium_clone.application.user.service.ProfileService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Optional;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProfileRestController.class)
 class ProfileRestControllerTest {
 
     @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockBean ProfileService profileService;
     @MockBean ProfileRepository profileRepository;
     private final String commonPath = "/api/profiles";
 
@@ -35,6 +42,25 @@ class ProfileRestControllerTest {
     public void testGetProfileNotFound() throws Exception {
         mockMvc.perform(get(commonPath + "/" + "notFound"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testUpdateProfile() throws Exception {
+        // given
+        String username = setTestUserProfile();
+        String updateUsername = "test2";
+        String updateBio = "bio";
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setUsername(updateUsername);
+        dto.setBio(updateBio);
+        String body = objectMapper.writeValueAsString(dto);
+
+        // then
+        mockMvc.perform(patch(commonPath + "/" + username)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
     }
 
     private String setTestUserProfile() {

--- a/src/test/java/com/example/medium_clone/application/user/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/service/ProfileServiceTest.java
@@ -60,6 +60,31 @@ class ProfileServiceTest {
         assertThat(profile.getBio()).isEqualTo(updatedBio);
     }
 
+    @Test
+    /*
+      업데이트하는 필드만 업데이트 되고 나머지 필드는 null로 바뀌지 않는지 테스트한다.
+     */
+    public void testUpdateNotNull() {
+        // given
+        String username = "test";
+        String updatedBio = "bio";
+        Profile profile = getProfile(username);
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setBio(updatedBio);
+
+        // mocking
+        setRepoMocking(username, profile);
+
+        // when
+        profileService.update(username, dto);
+
+        // then
+        // dto의 username이 null일 때, 즉 username은 요청 body에 없을 때
+        // 원래의 username이 null로 바뀌지 않는지 확인한다.
+        assertThat(dto.getUsername()).isEmpty();
+        assertThat(profile.getUsername()).isNotNull();
+    }
+
     private void setRepoMocking(String username, Profile profile) {
         when(profileRepository.findByUsername(username)).thenReturn(Optional.of(profile));
     }

--- a/src/test/java/com/example/medium_clone/application/user/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/service/ProfileServiceTest.java
@@ -1,0 +1,51 @@
+package com.example.medium_clone.application.user.service;
+
+import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.repository.ProfileRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+    @InjectMocks
+    private ProfileService profileService;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Test
+    public void testUpdateUsername() {
+        // given
+        String username = "test";
+        String updatedUsername = "test2";
+        Profile profile = getProfile(username);
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setUsername(updatedUsername);
+
+        // mocking
+        setRepoMocking(username, profile);
+
+        // when
+        profileService.update(username, dto);
+
+        // then
+        assertThat(profile.getUsername()).isEqualTo(updatedUsername);
+    }
+
+    private void setRepoMocking(String username, Profile profile) {
+        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(profile));
+    }
+
+    private Profile getProfile(String username){
+        return Profile.createProfile("", username);
+    }
+}

--- a/src/test/java/com/example/medium_clone/application/user/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/service/ProfileServiceTest.java
@@ -41,6 +41,25 @@ class ProfileServiceTest {
         assertThat(profile.getUsername()).isEqualTo(updatedUsername);
     }
 
+    @Test
+    public void testUpdateBio() {
+        // given
+        String username = "test";
+        String updatedBio = "bio";
+        Profile profile = getProfile(username);
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setBio(updatedBio);
+
+        // mocking
+        setRepoMocking(username, profile);
+
+        // when
+        profileService.update(username, dto);
+
+        // then
+        assertThat(profile.getBio()).isEqualTo(updatedBio);
+    }
+
     private void setRepoMocking(String username, Profile profile) {
         when(profileRepository.findByUsername(username)).thenReturn(Optional.of(profile));
     }


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- API를 통해 프로필의 유저 이름, 자기 소개를 변경할 수 있도록 합니다.

## 변경사항
- ProfileRestController 변경
  - profileService의 update를 이용
- ProfileService 추가
  - request body에 일부 필드만 왔을 때도 업데이트
  - `Optional.ifPresent`를 이용 
- ProfileUpdateDto 변경
  - request body에 일부 필드만 올 수 있으므로 getter에 Optional 표시 
- Profile Entity 변경
  - username, bio를 변경하는 메서드 추가
- 업데이트 테스트 추가
  - ProfileRestControllerTest
    - 해당 path에 username, bio를 body에 담아서 넘겨줬을 때 204 상태 코드가 오는지 테스트 
  - ProfileServiceTest
    - username, bio가 body에 넘겨준대로 바뀌는지 테스트
    - bio만 request body에 넘어왔을 때, username은 null로 안 바뀌는지 테스트

## 참고
- [realworld-springboot](https://github.com/raeperd/realworld-springboot-java/blob/55afe50708440db6a1321458d32322e1cb5091e1/src/main/java/io/github/raeperd/realworld/domain/user/UserService.java#L47)
- https://www.whiteship.me/optional-ifpresent/
