### PR TITLE
hotfix: Validate User registration DTO

### DIFF
--- a/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
@@ -18,7 +20,7 @@ public class UserRestController {
 
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
-    public User registerUser(@RequestBody UserRegisterDto dto) {
+    public User registerUser(@RequestBody @Valid UserRegisterDto dto) {
         Long memberId = userService.join(dto);
         return userRepository.findById(memberId).orElseThrow(IllegalStateException::new);
     }

--- a/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-@RestController()
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
 public class UserRestController {

--- a/src/test/java/com/example/medium_clone/application/user/controller/UserRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/controller/UserRestControllerTest.java
@@ -59,4 +59,57 @@ class UserRestControllerTest {
                 .andExpect(status().isCreated());
     }
 
+    @Test
+    public void testUsernameBlank400() throws Exception {
+        // given
+        UserRegisterDto dto = getUserRegisterDto();
+        dto.setUsername("");
+        String body = objectMapper.writeValueAsString(dto);
+
+        // then
+        mockMvc.perform(post(commonPath + "/register")
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testPasswordBlank400() throws Exception {
+        // given
+        UserRegisterDto dto = getUserRegisterDto();
+        dto.setPassword("");
+        String body = objectMapper.writeValueAsString(dto);
+
+        // then
+        mockMvc.perform(post(commonPath + "/register")
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testInvalidEmail400() throws Exception {
+        // given
+        UserRegisterDto dto = getUserRegisterDto();
+        dto.setEmail("test");
+        String body = objectMapper.writeValueAsString(dto);
+
+        // then
+        mockMvc.perform(post(commonPath + "/register")
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    private UserRegisterDto getUserRegisterDto() {
+        UserRegisterDto dto = new UserRegisterDto();
+        dto.setUsername("test");
+        dto.setPassword("password");
+        dto.setEmail("test@email.com");
+        return dto;
+    }
+
 }


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- 유저를 생성할 때 유효하지 않은 데이터를 요청하면 400 에러로 실패하게 만듭니다.

## 관련 이슈
Close #8 

## 변경사항
- UserRestController 변경
  -  registerUser 리퀘스트 바디에 `@Valid` 추가

## 참고
- https://reflectoring.io/bean-validation-with-spring-boot