### PR TITLE
hotfix: Make User and Profile nullable false

### DIFF
--- a/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
@@ -18,6 +18,7 @@ public class Profile extends BaseTimeEntity {
     @Column(name = "profile_id")
     private Long id;
     private String bio;
+    @Column(nullable = false)
     private String username;
 
     public static Profile createProfile(String bio, String username) {

--- a/src/main/java/com/example/medium_clone/application/user/entity/User.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/User.java
@@ -14,7 +14,9 @@ public class User extends BaseTimeEntity {
     @Id @GeneratedValue
     @Column(name = "user_id")
     private Long id;
+    @Column(nullable = false)
     private String password;
+    @Column(nullable = false)
     private String email;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- 유저, 프로필 엔티티를 저장할 때 필수적인 컬럼은 null이 될 수 없도록 만듭니다.

## 관련 이슈
Close #28 

## 변경사항
- Profile, User 엔티티 변경
  - `@Column(nullable = false)` 추가

## 참고
- https://velog.io/@gillog/JPA-Column-Annotation