### PR TITLE
feature: Add Article post

### DIFF
--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -1,0 +1,25 @@
+package com.example.medium_clone.application.article.controller;
+
+import com.example.medium_clone.application.article.dto.ArticleCreateDto;
+import com.example.medium_clone.application.article.entity.Article;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.github.slugify.Slugify;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/articles")
+public class ArticleRestController {
+
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
+    public Article createArticle(@RequestBody ArticleCreateDto dto) {
+        // 임시 객체 반환
+        // TODO: 없는 유저 처리 필요
+        Profile profile = Profile.createProfile("bio", "username");
+        return Article.createArticle(profile, "title", "body", "desc", new Slugify(), 10, 100);
+    }
+
+}

--- a/src/main/java/com/example/medium_clone/application/article/dto/ArticleCreateDto.java
+++ b/src/main/java/com/example/medium_clone/application/article/dto/ArticleCreateDto.java
@@ -1,0 +1,17 @@
+package com.example.medium_clone.application.article.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class ArticleCreateDto {
+
+    @NotBlank
+    private String username;
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String body;
+    private String description;
+}

--- a/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/Profile.java
@@ -2,6 +2,7 @@ package com.example.medium_clone.application.user.entity;
 
 import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.common.entity.BaseTimeEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -18,6 +19,7 @@ public class Profile extends BaseTimeEntity {
     @Column(name = "profile_id")
     private Long id;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "author")
     private List<Article> articles = new ArrayList<>();
 

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -1,0 +1,47 @@
+package com.example.medium_clone.application.article.controller;
+
+import com.example.medium_clone.application.article.dto.ArticleCreateDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ArticleRestController.class)
+class ArticleRestControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    private final String commonPath = "/api/articles";
+
+    @Test
+    public void testCreateArticle() throws Exception {
+        // given
+        String username = "username";
+        String title = "title";
+        String body = "body";
+        String desc = "";
+
+        ArticleCreateDto dto = new ArticleCreateDto();
+        dto.setUsername(username);
+        dto.setTitle(title);
+        dto.setBody(body);
+        dto.setDescription(desc);
+
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        // then
+        mockMvc.perform(post(commonPath)
+                .content(requestBody)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+    }
+
+}


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- 게시물을 생성할 수 있는 API를 제공합니다.

## 변경사항
- ArticleRestController 추가
  - 아티클 생성 추가 (POST `/api/articles`) 
    - 아직은 하드 코딩된 값만 반환 
- ArticleCreateDto 추가
- Profile entity 수정
  - 양뱡한 관계로 인한 Jackson infinite recursion 발생으로 `members`에 `@JsonIgnore` 추가

