### PR TITLE
feature: Add GET article by slug

### DIFF
--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -4,8 +4,6 @@ import com.example.medium_clone.application.article.dto.ArticleCreateDto;
 import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
 import com.example.medium_clone.application.article.service.ArticleService;
-import com.example.medium_clone.application.user.entity.Profile;
-import com.github.slugify.Slugify;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -25,6 +25,11 @@ public class ArticleRestController {
         return articleRepository.findById(articleId).orElseThrow(IllegalStateException::new);
     }
 
+    /**
+     * Get article by path variable slug.
+     *
+     * @return Article with its author which is Profile.
+     */
     @GetMapping("/{slug}")
     public Article getArticle(@PathVariable String slug) {
         return articleRepository.findBySlugFetchAuthor(slug).orElseThrow(NoSuchElementException::new);

--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -27,7 +27,7 @@ public class ArticleRestController {
 
     @GetMapping("/{slug}")
     public Article getArticle(@PathVariable String slug) {
-        return articleRepository.findBySlug(slug).orElseThrow(NoSuchElementException::new);
+        return articleRepository.findBySlugFetchAuthor(slug).orElseThrow(NoSuchElementException::new);
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.NoSuchElementException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/articles")
@@ -23,4 +25,14 @@ public class ArticleRestController {
         return articleRepository.findById(articleId).orElseThrow(IllegalStateException::new);
     }
 
+    @GetMapping("/{slug}")
+    public Article getArticle(@PathVariable String slug) {
+        return articleRepository.findBySlug(slug).orElseThrow(NoSuchElementException::new);
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoSuchElementException.class)
+    void handleNoSuchElementException(NoSuchElementException exception) {
+
+    }
 }

--- a/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
@@ -2,7 +2,12 @@ package com.example.medium_clone.application.article.repository;
 
 import com.example.medium_clone.application.article.entity.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    Optional<Article> findBySlug(@Param("slug") String slug);
 
 }

--- a/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
@@ -2,12 +2,14 @@ package com.example.medium_clone.application.article.repository;
 
 import com.example.medium_clone.application.article.entity.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
-    Optional<Article> findBySlug(@Param("slug") String slug);
+    @Query("select a from Article a left join fetch a.author where a.slug = :slug")
+    Optional<Article> findBySlugFetchAuthor(@Param("slug") String slug);
 
 }

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -65,7 +65,7 @@ class ArticleRestControllerTest {
         String slug = article.getSlug();
 
         // mocking
-        when(articleRepository.findBySlug(slug)).thenReturn(Optional.of(article));
+        when(articleRepository.findBySlugFetchAuthor(slug)).thenReturn(Optional.of(article));
 
         // then
         mockMvc.perform(get(commonPath + "/" + slug))
@@ -78,7 +78,7 @@ class ArticleRestControllerTest {
         String slug = "not-found-123abc";
 
         // mocking
-        when(articleRepository.findBySlug(slug)).thenReturn(Optional.empty());
+        when(articleRepository.findBySlugFetchAuthor(slug)).thenReturn(Optional.empty());
 
         // then
         mockMvc.perform(get(commonPath + "/" + slug))

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -57,6 +57,22 @@ class ArticleRestControllerTest {
     }
 
     @Test
+    public void testGetArticle() throws Exception {
+        // given
+        ArticleCreateDto dto = getArticleCreateDto();
+        Profile author = Profile.createProfile("bio", dto.getUsername());
+        Article article = Article.createArticle(author, dto.getTitle(), dto.getBody(), dto.getDescription(), slugify, 10, 200);
+        String slug = article.getSlug();
+
+        // mocking
+        when(articleRepository.findBySlug(slug)).thenReturn(Optional.of(article));
+
+        // then
+        mockMvc.perform(get(commonPath + "/" + slug))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     public void testCreateArticleAuthorNotFound() throws Exception {
         // given
         ArticleCreateDto dto = getArticleCreateDto();
@@ -71,22 +87,6 @@ class ArticleRestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void testGetArticle() throws Exception {
-        // given
-        ArticleCreateDto dto = getArticleCreateDto();
-        Profile author = Profile.createProfile("bio", dto.getUsername());
-        Article article = Article.createArticle(author, dto.getTitle(), dto.getBody(), dto.getDescription(), slugify, 10, 200);
-        String slug = article.getSlug();
-
-        // mocking
-        when(articleRepository.findBySlug(slug)).thenReturn(Optional.of(article));
-
-        // then
-        mockMvc.perform(get(commonPath + "/" + slug))
-                .andExpect(status().isOk());
     }
 
     private ArticleCreateDto getArticleCreateDto() {

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -73,6 +73,19 @@ class ArticleRestControllerTest {
     }
 
     @Test
+    public void testGetArticleNotFound() throws Exception {
+        // given
+        String slug = "not-found-123abc";
+
+        // mocking
+        when(articleRepository.findBySlug(slug)).thenReturn(Optional.empty());
+
+        // then
+        mockMvc.perform(get(commonPath + "/" + slug))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
     public void testCreateArticleAuthorNotFound() throws Exception {
         // given
         ArticleCreateDto dto = getArticleCreateDto();

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ArticleRestController.class)
@@ -70,6 +71,22 @@ class ArticleRestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testGetArticle() throws Exception {
+        // given
+        ArticleCreateDto dto = getArticleCreateDto();
+        Profile author = Profile.createProfile("bio", dto.getUsername());
+        Article article = Article.createArticle(author, dto.getTitle(), dto.getBody(), dto.getDescription(), slugify, 10, 200);
+        String slug = article.getSlug();
+
+        // mocking
+        when(articleRepository.findBySlug(slug)).thenReturn(Optional.of(article));
+
+        // then
+        mockMvc.perform(get(commonPath + "/" + slug))
+                .andExpect(status().isOk());
     }
 
     private ArticleCreateDto getArticleCreateDto() {

--- a/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
@@ -4,10 +4,16 @@ import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
 import com.github.slugify.Slugify;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -25,4 +31,22 @@ class ArticleRepositoryTest {
         Article article = Article.createArticle(profile, "test", "Test", "test", new Slugify(), 20, 100);
         articleRepository.save(article);
     }
+
+    @Test
+    public void testFindBySlugFetchAuthor() {
+        // given
+        Profile profile = Profile.createProfile("test", "test");
+        profileRepository.save(profile);
+
+        Article article = Article.createArticle(profile, "test", "Test", "test", new Slugify(), 20, 100);
+        articleRepository.save(article);
+
+        // when
+        Article foundArticle = articleRepository.findBySlugFetchAuthor(article.getSlug()).orElseThrow(NoSuchElementException::new);
+
+        // then
+        assertThat(foundArticle).isEqualTo(article);
+        assertThat(foundArticle.getAuthor()).isEqualTo(profile);
+    }
+
 }


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- slug을 통해 원하는 article을 조회할 수 있도록 합니다.

## 변경사항
- ArticleRestController 변경
  - GET /api/articles/slug 추가 
- ArticleRepository 변경
  - findBySlugFetchAuthor 추가
    - article을 가져올 때 author의 username도 필요하므로 fetch join으로 author도 같이 가져오도록 했습니다.
    - 이렇게 하지 않으면 `GET /api/articles/slug`을 했을 때, author가 프록시 객체여서 에러가 발생합니다.
- 테스트
  - GET /api/articles/slug
    - 존재하는 slug로 조회했을 때 status가 200 OK  인지
    - 존재하지 않는 slug로 조회했을 때 status가 404 Not Found 인지
  - findBySlugFetchAuthor 
    - slug로 조회한 article과 article의 author가 생성한 것과 동일한지 

## 참고
- https://ict-nroo.tistory.com/132