### PR TITLE
feature: Add list articles

### DIFF
--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -29,8 +29,8 @@ public class ArticleRestController {
     }
 
     @GetMapping
-    public Page<ArticleProjection> getArticles(Pageable pageable, @RequestParam String authorName) {
-        return articleRepository.findAllByAuthorUsername(pageable, authorName);
+    public Page<ArticleProjection> getArticles(Pageable pageable, @RequestParam(required = false) String authorName) {
+        return articleService.getArticles(pageable, authorName);
     }
 
     /**

--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -2,9 +2,12 @@ package com.example.medium_clone.application.article.controller;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
 import com.example.medium_clone.application.article.entity.Article;
+import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
 import com.example.medium_clone.application.article.service.ArticleService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +26,11 @@ public class ArticleRestController {
     public Article createArticle(@RequestBody ArticleCreateDto dto) {
         Long articleId = articleService.create(dto);
         return articleRepository.findById(articleId).orElseThrow(IllegalStateException::new);
+    }
+
+    @GetMapping
+    public Page<ArticleProjection> getArticles(Pageable pageable, @RequestParam String authorName) {
+        return articleRepository.findAllByAuthorUsername(pageable, authorName);
     }
 
     /**

--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -28,6 +28,10 @@ public class ArticleRestController {
         return articleRepository.findById(articleId).orElseThrow(IllegalStateException::new);
     }
 
+    /**
+     * Get ArticleProjection page.
+     * @return Page<ArticleProjection>
+     */
     @GetMapping
     public Page<ArticleProjection> getArticles(Pageable pageable, @RequestParam(required = false) String authorName) {
         return articleService.getArticles(pageable, authorName);

--- a/src/main/java/com/example/medium_clone/application/article/repository/ArticleProjection.java
+++ b/src/main/java/com/example/medium_clone/application/article/repository/ArticleProjection.java
@@ -1,0 +1,11 @@
+package com.example.medium_clone.application.article.repository;
+
+public interface ArticleProjection {
+
+    Long getId();
+    String getTitle();
+    String getSlug();
+    String getDescription();
+    String getAuthorUsername();
+
+}

--- a/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
@@ -15,4 +15,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Optional<Article> findBySlugFetchAuthor(@Param("slug") String slug);
 
     Page<ArticleProjection> findAllByAuthorUsername(Pageable pageable, @Param("authorName") String authorName);
+
+    @Query(value = "select a.article_id as id, a.title, a.slug, a.description, p.username as authorUsername "
+        + "from article a left join profile p",
+        countQuery = "select count(*) from article",
+        nativeQuery = true)
+    Page<ArticleProjection> findAllProjection(Pageable pageable);
 }

--- a/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
@@ -1,6 +1,8 @@
 package com.example.medium_clone.application.article.repository;
 
 import com.example.medium_clone.application.article.entity.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,4 +14,5 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("select a from Article a left join fetch a.author where a.slug = :slug")
     Optional<Article> findBySlugFetchAuthor(@Param("slug") String slug);
 
+    Page<ArticleProjection> findAllByAuthorUsername(Pageable pageable, @Param("authorName") String authorName);
 }

--- a/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
+++ b/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
@@ -2,13 +2,17 @@ package com.example.medium_clone.application.article.service;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
 import com.example.medium_clone.application.article.entity.Article;
+import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.service.ProfileService;
 import com.github.slugify.Slugify;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Objects;
 
@@ -51,5 +55,13 @@ public class ArticleService {
         Article savedArticle = articleRepository.save(article);
 
         return savedArticle.getId();
+    }
+
+    public Page<ArticleProjection> getArticles(Pageable pageable, @RequestParam String authorName) {
+        if (authorName == null) {
+            return articleRepository.findAllProjection(pageable);
+        } else {
+            return articleRepository.findAllByAuthorUsername(pageable, authorName);
+        }
     }
 }

--- a/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
+++ b/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
@@ -57,6 +57,11 @@ public class ArticleService {
         return savedArticle.getId();
     }
 
+    /**
+     * Get ArticleProjection page.
+     * Get articles of specified author if you pass authorName.
+     * @return Page<ArticleProjection>
+     */
     public Page<ArticleProjection> getArticles(Pageable pageable, @RequestParam String authorName) {
         if (authorName == null) {
             return articleRepository.findAllProjection(pageable);

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -109,7 +109,7 @@ class ArticleRestControllerTest {
     }
 
     @Test
-    public void testGetArticles() throws Exception {
+    public void testGetArticlesAuthorName() throws Exception {
         // given
         String authorName = "test";
         int offset = 0;
@@ -118,10 +118,29 @@ class ArticleRestControllerTest {
         Page<ArticleProjection> page = mock(Page.class);
 
         // mocking
-        when(articleRepository.findAllByAuthorUsername(pageable, authorName)).thenReturn(page);
+        when(articleService.getArticles(pageable, authorName)).thenReturn(page);
 
         // then
         mockMvc.perform(get(commonPath).param("authorName", authorName)
+                        .param("pageSize", Integer.toString(pageSize))
+                        .param("offset", Integer.toString(offset)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testGetArticles() throws Exception {
+        // given
+        String authorName = null;
+        int offset = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(offset, pageSize);
+        Page<ArticleProjection> page = mock(Page.class);
+
+        // mocking
+        when(articleService.getArticles(pageable, authorName)).thenReturn(page);
+
+        // then
+        mockMvc.perform(get(commonPath)
                         .param("pageSize", Integer.toString(pageSize))
                         .param("offset", Integer.toString(offset)))
                 .andExpect(status().isOk());

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -2,6 +2,7 @@ package com.example.medium_clone.application.article.controller;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
 import com.example.medium_clone.application.article.entity.Article;
+import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
 import com.example.medium_clone.application.article.service.ArticleService;
 import com.example.medium_clone.application.user.entity.Profile;
@@ -12,12 +13,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -100,6 +106,25 @@ class ArticleRestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testGetArticles() throws Exception {
+        // given
+        String authorName = "test";
+        int offset = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(offset, pageSize);
+        Page<ArticleProjection> page = mock(Page.class);
+
+        // mocking
+        when(articleRepository.findAllByAuthorUsername(pageable, authorName)).thenReturn(page);
+
+        // then
+        mockMvc.perform(get(commonPath).param("authorName", authorName)
+                        .param("pageSize", Integer.toString(pageSize))
+                        .param("offset", Integer.toString(offset)))
+                .andExpect(status().isOk());
     }
 
     private ArticleCreateDto getArticleCreateDto() {

--- a/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
@@ -73,7 +73,7 @@ class ArticleRepositoryTest {
     }
 
     @Test
-    public void findAllProjection() {
+    public void testFindAllProjection() {
         // given
         String username = "test";
         Profile profile = Profile.createProfile("test", username);

--- a/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
@@ -4,16 +4,16 @@ import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.repository.ProfileRepository;
 import com.github.slugify.Slugify;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -47,6 +47,29 @@ class ArticleRepositoryTest {
         // then
         assertThat(foundArticle).isEqualTo(article);
         assertThat(foundArticle.getAuthor()).isEqualTo(profile);
+    }
+
+    @Test
+    public void testFindAllByAuthor() {
+        // given
+        String username = "test";
+        Profile profile = Profile.createProfile("test", username);
+        profileRepository.save(profile);
+
+        for (int i = 0; i < 10; ++i) {
+            Article article = Article.createArticle(profile, "test", "Test", "test", new Slugify(), 20, 100);
+            articleRepository.save(article);
+        }
+
+        int page = 0;
+        int size = 5;
+
+        // when
+        Page<ArticleProjection> articles = articleRepository.findAllByAuthorUsername(PageRequest.of(page, size), username);
+
+        // then
+        assertThat(articles.getNumberOfElements()).isEqualTo(size);
+        assertThat(articles.getNumber()).isEqualTo(page);
     }
 
 }

--- a/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/repository/ArticleRepositoryTest.java
@@ -72,4 +72,27 @@ class ArticleRepositoryTest {
         assertThat(articles.getNumber()).isEqualTo(page);
     }
 
+    @Test
+    public void findAllProjection() {
+        // given
+        String username = "test";
+        Profile profile = Profile.createProfile("test", username);
+        profileRepository.save(profile);
+
+        for (int i = 0; i < 10; ++i) {
+            Article article = Article.createArticle(profile, "test", "Test", "test", new Slugify(), 20, 100);
+            articleRepository.save(article);
+        }
+
+        int page = 0;
+        int size = 5;
+
+        // when
+        Page<ArticleProjection> articles = articleRepository.findAllProjection(PageRequest.of(page, size));
+
+        // then
+        assertThat(articles.getNumberOfElements()).isEqualTo(size);
+        assertThat(articles.getNumber()).isEqualTo(page);
+    }
+
 }

--- a/src/test/java/com/example/medium_clone/application/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/service/ArticleServiceTest.java
@@ -2,6 +2,7 @@ package com.example.medium_clone.application.article.service;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
 import com.example.medium_clone.application.article.entity.Article;
+import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.service.ProfileService;
@@ -11,6 +12,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -62,5 +66,37 @@ class ArticleServiceTest {
 
         // then
         assertThat(createdId).isEqualTo(fakeId);
+    }
+
+    @Test
+    public void testGetArticlesAuthorNameNull() {
+        // given
+        String authorName = null;
+        int offset = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(offset, pageSize);
+        Page<ArticleProjection> page = mock(Page.class);
+
+        // mocking
+        when(articleRepository.findAllProjection(pageable)).thenReturn(page);
+
+        // then
+        articleService.getArticles(pageable, authorName);
+    }
+
+    @Test
+    public void testGetArticlesAuthorName() {
+        // given
+        String authorName = "test";
+        int offset = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(offset, pageSize);
+        Page<ArticleProjection> page = mock(Page.class);
+
+        // mocking
+        when(articleRepository.findAllByAuthorUsername(pageable, authorName)).thenReturn(page);
+
+        // then
+        articleService.getArticles(pageable, authorName);
     }
 }


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- article 리스트를 조회할 수 있습니다.
- `authorName` 파라미터를 넘겨줄 시 `authorName`에 해당하는 article들을 조회할 수 있습니다.

## 변경사항
- ArticleProjection 추가
  - Article list를 가져올 때 일부 필드만 필요하므로 projection을 통해 일부 필드만 가져오도록 한다. 
- ArticleRepository 변경
  - paging으로 모든 article을 가져올 수 있도록 하는 `findAllProjection` 추가
  - `findAllProjection`과 비슷하지만 특정 author name에 해당하는 article들만 가져오는 `findAllByAuthorUsername` 추가
- ArticleRestController 변경
  - `GET /api/articles`로 article list를 가져오는 API 추가
- ArticleService 변경
  - `authorName` 파라미터에 따라 `articleRepository`에서 알맞은 메서드 호출
- 테스트
  - ArticleRepository에서 `findAllProjection`과 `testFindAllProjection`이 제대로 동작하고 page offset과 size만큼 가져오는지 테스트
  - ArticleService에서 authorName 파라미터 존재 여부에 따라 알맞은 메서드를 호출하는지 테스트
  - ArticleRestController에서 page offset과 page size만큼 요청시 응답으로 200 OK가 오는지 테스트

## 참고
- [How can i test paginated result in spring boot?](https://stackoverflow.com/questions/68325779/how-can-i-test-paginated-result-in-spring-boot)
