### PR TITLE
hotfix: Show sort param in swagger

### DIFF
--- a/src/main/java/com/example/medium_clone/SwaggerConfig.java
+++ b/src/main/java/com/example/medium_clone/SwaggerConfig.java
@@ -1,9 +1,16 @@
 package com.example.medium_clone;
 
+import com.fasterxml.classmate.TypeResolver;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.AlternateTypeRules;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -14,10 +21,28 @@ public class SwaggerConfig {
 
     @Bean
     public Docket api() {
+        TypeResolver typeResolver = new TypeResolver();
+
         return new Docket(DocumentationType.SWAGGER_2)
+                .alternateTypeRules(
+                        AlternateTypeRules.newRule(typeResolver.resolve(Pageable.class), typeResolver.resolve(Page.class))
+                )
                 .select()
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.any())
                 .build();
+    }
+
+    @Getter @Setter
+    @ApiModel
+    static class Page {
+        @ApiModelProperty(value = "page")
+        private Integer page;
+
+        @ApiModelProperty(value = "page size", allowableValues = "range[0, 10]")
+        private Integer size;
+
+        @ApiModelProperty(value = "sort[ex) created_date,(asc|desc)]")
+        private String sort;
     }
 }

--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -8,6 +8,8 @@ import com.example.medium_clone.application.article.service.ArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,7 +35,7 @@ public class ArticleRestController {
      * @return Page<ArticleProjection>
      */
     @GetMapping
-    public Page<ArticleProjection> getArticles(Pageable pageable, @RequestParam(required = false) String authorName) {
+    public Page<ArticleProjection> getArticles(@SortDefault(sort="created_date", direction = Sort.Direction.DESC) Pageable pageable, @RequestParam(required = false) String authorName) {
         return articleService.getArticles(pageable, authorName);
     }
 


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- Swagger에서 sort 파라미터가 보이도록 만듭니다.

## 관련 이슈
- Close #39 
- Swagger2에서 sort 파라미터가 제대로 보이지 않는 이슈가 있다고 합니다.

## 변경사항
- SwaggerConfig
  - Page 클래스를 추가해 page, size, sort를 지정할 수 있도록 만듦. 
- ArticleRestController 변경
  - @SortDefault로 생성일 내림차순을 기본 솔팅으로 지정

## 참고
- https://blog.jiniworld.me/20
  - 해당 블로그 해결법을 사용했습니다. 
- https://shlee0882.tistory.com/287
- https://dar0m.tistory.com/61
