### PR TITLE
feature: Add Article update

### DIFF
--- a/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
+++ b/src/main/java/com/example/medium_clone/application/article/controller/ArticleRestController.java
@@ -1,6 +1,7 @@
 package com.example.medium_clone.application.article.controller;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
+import com.example.medium_clone.application.article.dto.ArticleUpdateDto;
 import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.NoSuchElementException;
@@ -47,6 +49,16 @@ public class ArticleRestController {
     @GetMapping("/{slug}")
     public Article getArticle(@PathVariable String slug) {
         return articleRepository.findBySlugFetchAuthor(slug).orElseThrow(NoSuchElementException::new);
+    }
+
+    /**
+     * Update article which has given slug.
+     * @return Response entity of no content.
+     */
+    @PatchMapping("/{slug}")
+    public ResponseEntity<Article> updateArticle(@PathVariable String slug, @RequestBody ArticleUpdateDto dto) {
+        articleService.update(slug, dto);
+        return ResponseEntity.noContent().build();
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/example/medium_clone/application/article/dto/ArticleUpdateDto.java
+++ b/src/main/java/com/example/medium_clone/application/article/dto/ArticleUpdateDto.java
@@ -1,0 +1,26 @@
+package com.example.medium_clone.application.article.dto;
+
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Data
+public class ArticleUpdateDto {
+
+    private String title;
+    private String body;
+    private String description;
+
+    public Optional<String> getTitle() {
+        return Optional.ofNullable(this.title);
+    }
+
+    public Optional<String> getBody() {
+        return Optional.ofNullable(this.body);
+    }
+
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(this.description);
+    }
+}

--- a/src/main/java/com/example/medium_clone/application/article/entity/Article.java
+++ b/src/main/java/com/example/medium_clone/application/article/entity/Article.java
@@ -46,6 +46,21 @@ public class Article extends BaseTimeEntity {
     private String body;
     private String description;
 
+    public void setTitle(String title) {
+        Objects.requireNonNull(title, "title");
+        this.title = title;
+    }
+
+    public void setBody(String body) {
+        Objects.requireNonNull(body, "body");
+        this.body = body;
+    }
+
+    public void setDescription(String description) {
+        Objects.requireNonNull(description, "description");
+        this.description = description;
+    }
+
     /**
      * Set author to this article instance.
      * Add this article to author's article list.

--- a/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/medium_clone/application/article/repository/ArticleRepository.java
@@ -14,6 +14,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("select a from Article a left join fetch a.author where a.slug = :slug")
     Optional<Article> findBySlugFetchAuthor(@Param("slug") String slug);
 
+    Optional<Article> findBySlug(@Param("slug") String slug);
+
     Page<ArticleProjection> findAllByAuthorUsername(Pageable pageable, @Param("authorName") String authorName);
 
     @Query(value = "select a.article_id as id, a.title, a.slug, a.description, p.username as authorUsername "

--- a/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
+++ b/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
@@ -1,6 +1,7 @@
 package com.example.medium_clone.application.article.service;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
+import com.example.medium_clone.application.article.dto.ArticleUpdateDto;
 import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 @Service
@@ -68,5 +70,20 @@ public class ArticleService {
         } else {
             return articleRepository.findAllByAuthorUsername(pageable, authorName);
         }
+    }
+
+    /**
+     * Update article which has given slug.
+     * @return article Id
+     */
+    @Transactional
+    public Long update(String slug, ArticleUpdateDto dto) {
+        Article article = articleRepository.findBySlug(slug).orElseThrow(NoSuchElementException::new);
+
+        dto.getBody().ifPresent(article::setBody);
+        dto.getTitle().ifPresent(article::setTitle);
+        dto.getDescription().ifPresent(article::setDescription);
+
+        return article.getId();
     }
 }

--- a/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
+++ b/src/main/java/com/example/medium_clone/application/article/service/ArticleService.java
@@ -81,6 +81,8 @@ public class ArticleService {
         Article article = articleRepository.findBySlug(slug).orElseThrow(NoSuchElementException::new);
 
         dto.getBody().ifPresent(article::setBody);
+        // Don't modify slug.
+        // Slug is enough to identify the article.
         dto.getTitle().ifPresent(article::setTitle);
         dto.getDescription().ifPresent(article::setDescription);
 

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.medium_clone.application.article.controller;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
+import com.example.medium_clone.application.article.dto.ArticleUpdateDto;
 import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
@@ -20,13 +21,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.ArrayList;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ArticleRestController.class)
@@ -144,6 +145,50 @@ class ArticleRestControllerTest {
                         .param("pageSize", Integer.toString(pageSize))
                         .param("offset", Integer.toString(offset)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testUpdateArticle() throws Exception {
+        // given
+        String slug = "test-24nf1";
+        String updateTitle = "update";
+        ArticleUpdateDto dto = new ArticleUpdateDto();
+        dto.setTitle(updateTitle);
+
+        String body = objectMapper.writeValueAsString(dto);
+
+        // mocking
+        Long fakeId = 1L;
+        when(articleService.update(slug, dto)).thenReturn(fakeId);
+
+        // then
+        mockMvc.perform(patch(commonPath + "/" + slug)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void testUpdateArticleNotFound() throws Exception {
+        // given
+        String slug = "test-24nf1";
+        String updateTitle = "update";
+        ArticleUpdateDto dto = new ArticleUpdateDto();
+        dto.setTitle(updateTitle);
+
+        String body = objectMapper.writeValueAsString(dto);
+
+        // mocking
+        Long fakeId = 1L;
+        when(articleService.update(slug, dto)).thenThrow(NoSuchElementException.class);
+
+        // then
+        mockMvc.perform(patch(commonPath + "/" + slug)
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 
     private ArticleCreateDto getArticleCreateDto() {

--- a/src/test/java/com/example/medium_clone/application/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/service/ArticleServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.medium_clone.application.article.service;
 
 import com.example.medium_clone.application.article.dto.ArticleCreateDto;
+import com.example.medium_clone.application.article.dto.ArticleUpdateDto;
 import com.example.medium_clone.application.article.entity.Article;
 import com.example.medium_clone.application.article.repository.ArticleProjection;
 import com.example.medium_clone.application.article.repository.ArticleRepository;
@@ -15,6 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -98,5 +101,40 @@ class ArticleServiceTest {
 
         // then
         articleService.getArticles(pageable, authorName);
+    }
+
+    @Test
+    public void testUpdateTitle() {
+        /*
+        title을 업데이트할 때 title이 제대로 바뀌는지 다른 프로퍼티는 null로 설정되지 않는지 확인한다.
+        또한, slug도 바뀌지 않는지 확인한다.
+         */
+
+        // given
+        String updateTitle = "update";
+
+        ArticleUpdateDto dto = new ArticleUpdateDto();
+        dto.setTitle(updateTitle);
+
+        Article article = getArticle();
+        String slug = article.getSlug();
+
+        // mocking
+        when(articleRepository.findBySlug(slug)).thenReturn(Optional.of(article));
+
+        // when
+        articleService.update(slug, dto);
+
+        // then
+        assertThat(article.getTitle()).isEqualTo(updateTitle);
+        assertThat(article.getBody()).isNotNull();
+        assertThat(article.getDescription()).isNotNull();
+        assertThat(article.getSlug()).isEqualTo(slug);
+    }
+
+    private Article getArticle() {
+        Profile profile = mock(Profile.class);
+        when(slugify.slugify(any(String.class))).thenReturn("slug");
+        return Article.createArticle(profile, "title", "body", "desc", slugify, 10, 20);
     }
 }


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- Article을 변경할 수 있습니다.

## 변경사항
- ArticleRestController 변경
  - `PATCH /api/articles/{slug}`로 article 업데이트
- ArticleUpdateDto 추가
  - title, body, description 업데이트 
- ArticleService 변경
  - dto에서 null이 아닌 프로퍼티를 변경 
- ArticleRepository 변경
  - `findBySlug` 추가
- Article entity 변경
  - title, body, description setter 추가 
- 테스트
  - ArticleService에서 title 업데이트이 제대로 되는지 테스트
  - ArticleController에서 응답이 정상적일 때 204가 나오는지, 주어진 slug가 없을 때 404가 나오는지 테스트