### PR TITLE
refactor: Return user profile dto

### DIFF
--- a/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/ProfileRestController.java
@@ -1,9 +1,10 @@
 package com.example.medium_clone.application.user.controller;
 
+import com.example.medium_clone.application.user.dto.ProfileGetDto;
 import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.exception.ProfileNotFoundException;
-import com.example.medium_clone.application.user.repository.ProfileRepository;
+import com.example.medium_clone.application.user.repository.ProfileQueryRepository;
 import com.example.medium_clone.application.user.service.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,11 +16,11 @@ import org.springframework.web.bind.annotation.*;
 public class ProfileRestController {
 
     private final ProfileService profileService;
-    private final ProfileRepository profileRepository;
+    private final ProfileQueryRepository profileQueryRepository;
 
     @GetMapping("/{username}")
-    public Profile getProfile(@PathVariable String username) {
-        return profileRepository.findByUsername(username).orElseThrow(() -> new ProfileNotFoundException(username));
+    public ProfileGetDto getProfile(@PathVariable String username) {
+        return profileQueryRepository.findProfileGetDtoByUsername(username).orElseThrow(() -> new ProfileNotFoundException(username));
     }
 
     @PatchMapping("/{username}")

--- a/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
+++ b/src/main/java/com/example/medium_clone/application/user/controller/UserRestController.java
@@ -1,8 +1,8 @@
 package com.example.medium_clone.application.user.controller;
 
 import com.example.medium_clone.application.user.dto.UserRegisterDto;
-import com.example.medium_clone.application.user.entity.User;
-import com.example.medium_clone.application.user.repository.UserRepository;
+import com.example.medium_clone.application.user.dto.UserRegisterResponseDto;
+import com.example.medium_clone.application.user.repository.UserQueryRepository;
 import com.example.medium_clone.application.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,12 +16,12 @@ import javax.validation.Valid;
 public class UserRestController {
 
     private final UserService userService;
-    private final UserRepository userRepository;
+    private final UserQueryRepository userQueryRepository;
 
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
-    public User registerUser(@RequestBody @Valid UserRegisterDto dto) {
+    public UserRegisterResponseDto registerUser(@RequestBody @Valid UserRegisterDto dto) {
         Long memberId = userService.join(dto);
-        return userRepository.findById(memberId).orElseThrow(IllegalStateException::new);
+        return userQueryRepository.findUserRegisterResponseDtoById(memberId).orElseThrow(IllegalStateException::new);
     }
 }

--- a/src/main/java/com/example/medium_clone/application/user/dto/ProfileGetDto.java
+++ b/src/main/java/com/example/medium_clone/application/user/dto/ProfileGetDto.java
@@ -1,0 +1,14 @@
+package com.example.medium_clone.application.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ProfileGetDto {
+
+    private Long id;
+    private String bio;
+    private String username;
+
+}

--- a/src/main/java/com/example/medium_clone/application/user/dto/UserRegisterResponseDto.java
+++ b/src/main/java/com/example/medium_clone/application/user/dto/UserRegisterResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.medium_clone.application.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserRegisterResponseDto {
+    private String username;
+    private String email;
+}

--- a/src/main/java/com/example/medium_clone/application/user/repository/ProfileQueryRepository.java
+++ b/src/main/java/com/example/medium_clone/application/user/repository/ProfileQueryRepository.java
@@ -1,0 +1,16 @@
+package com.example.medium_clone.application.user.repository;
+
+import com.example.medium_clone.application.user.dto.ProfileGetDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ProfileQueryRepository extends JpaRepository<Profile, Long> {
+
+    @Query("select new com.example.medium_clone.application.user.dto.ProfileGetDto(p.id, p.bio, p.username) from Profile p where p.username = :username")
+    Optional<ProfileGetDto> findProfileGetDtoByUsername(@Param("username") String username);
+
+}

--- a/src/main/java/com/example/medium_clone/application/user/repository/UserQueryRepository.java
+++ b/src/main/java/com/example/medium_clone/application/user/repository/UserQueryRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface UserQueryRepository extends JpaRepository<User, Long> {
-    @Query("select new com.example.medium_clone.application.user.dto.UserRegisterResponseDto(p.username, u.email) from User u join u.profile p")
+    @Query("select new com.example.medium_clone.application.user.dto.UserRegisterResponseDto(p.username, u.email) from User u join u.profile p where u.id = :user_id")
     Optional<UserRegisterResponseDto> findUserRegisterResponseDtoById(@Param("user_id") Long id);
 
 }

--- a/src/main/java/com/example/medium_clone/application/user/repository/UserQueryRepository.java
+++ b/src/main/java/com/example/medium_clone/application/user/repository/UserQueryRepository.java
@@ -1,0 +1,15 @@
+package com.example.medium_clone.application.user.repository;
+
+import com.example.medium_clone.application.user.dto.UserRegisterResponseDto;
+import com.example.medium_clone.application.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface UserQueryRepository extends JpaRepository<User, Long> {
+    @Query("select new com.example.medium_clone.application.user.dto.UserRegisterResponseDto(p.username, u.email) from User u join u.profile p")
+    Optional<UserRegisterResponseDto> findUserRegisterResponseDtoById(@Param("user_id") Long id);
+
+}

--- a/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
@@ -1,10 +1,9 @@
 package com.example.medium_clone.application.user.controller;
 
+import com.example.medium_clone.application.user.dto.ProfileGetDto;
 import com.example.medium_clone.application.user.dto.ProfileUpdateDto;
-import com.example.medium_clone.application.user.entity.Profile;
-import com.example.medium_clone.application.user.repository.ProfileRepository;
+import com.example.medium_clone.application.user.repository.ProfileQueryRepository;
 import com.example.medium_clone.application.user.service.ProfileService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +25,7 @@ class ProfileRestControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
     @MockBean ProfileService profileService;
-    @MockBean ProfileRepository profileRepository;
+    @MockBean ProfileQueryRepository profileQueryRepository;
     private final String commonPath = "/api/profiles";
 
     @Test
@@ -71,13 +70,11 @@ class ProfileRestControllerTest {
         ProfileUpdateDto dto = new ProfileUpdateDto();
         dto.setUsername(username);
 
-        Profile profile = Profile.builder()
-                .bio(bio)
-                .username(username)
-                .build();
+        Long fakeId = 1L;
+        ProfileGetDto getDto = new ProfileGetDto(fakeId, bio, username);
 
         // mocking
-        when(profileRepository.findByUsername(username)).thenReturn(Optional.of(profile));
+        when(profileQueryRepository.findProfileGetDtoByUsername(username)).thenReturn(Optional.of(getDto));
 
         return username;
     }

--- a/src/test/java/com/example/medium_clone/application/user/controller/UserRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/controller/UserRestControllerTest.java
@@ -1,12 +1,15 @@
 package com.example.medium_clone.application.user.controller;
 
 import com.example.medium_clone.application.user.dto.UserRegisterDto;
+import com.example.medium_clone.application.user.dto.UserRegisterResponseDto;
 import com.example.medium_clone.application.user.entity.Profile;
 import com.example.medium_clone.application.user.entity.User;
+import com.example.medium_clone.application.user.repository.UserQueryRepository;
 import com.example.medium_clone.application.user.repository.UserRepository;
 import com.example.medium_clone.application.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -16,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -26,7 +30,7 @@ class UserRestControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
     @MockBean UserService userService;
-    @MockBean UserRepository userRepository;
+    @MockBean UserQueryRepository userQueryRepository;
     private final String commonPath = "/api/users";
 
     @Test
@@ -43,20 +47,13 @@ class UserRestControllerTest {
         dto.setEmail(email);
         String body = objectMapper.writeValueAsString(dto);
 
-        Profile profile = Profile.builder()
-                .bio(bio)
-                .username(username)
-                .build();
-        User user = User.builder()
-                .password(password)
-                .email(email)
-                .profile(profile)
-                .build();
+        UserRegisterResponseDto responseDto = new UserRegisterResponseDto(username, email);
+
         Long fakeId = 1L;
 
         // mocking
         when(userService.join(any(UserRegisterDto.class))).thenReturn(fakeId);
-        when(userRepository.findById(fakeId)).thenReturn(Optional.of(user));
+        when(userQueryRepository.findUserRegisterResponseDtoById(fakeId)).thenReturn(Optional.of(responseDto));
 
         // then
         mockMvc.perform(post(commonPath + "/register")

--- a/src/test/java/com/example/medium_clone/application/user/repository/UserQueryRepositoryTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/repository/UserQueryRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.example.medium_clone.application.user.repository;
+
+import com.example.medium_clone.application.user.dto.UserRegisterResponseDto;
+import com.example.medium_clone.application.user.entity.Profile;
+import com.example.medium_clone.application.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class UserQueryRepositoryTest {
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    UserQueryRepository userQueryRepository;
+
+    @Test
+    public void testFindUserRegisterResponseDtoById() {
+        // given
+        Long id = saveUser();
+
+        // when
+        UserRegisterResponseDto dto = userQueryRepository.findUserRegisterResponseDtoById(id)
+                .orElseThrow(IllegalStateException::new);
+
+        // then
+        User savedUser = userRepository.findById(id)
+                .orElseThrow(IllegalStateException::new);
+        assertThat(dto.getEmail()).isEqualTo(savedUser.getEmail());
+        assertThat(dto.getUsername()).isEqualTo(savedUser.getProfile().getUsername());
+    }
+
+    private Long saveUser() {
+        Profile profile = Profile.builder()
+                .username("test")
+                .bio("")
+                .build();
+
+        User user = User.builder()
+                .password("password")
+                .email("email@test.com")
+                .profile(profile)
+                .build();
+
+        userRepository.save(user);
+        return user.getId();
+    }
+}


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- 컨트롤러에서 DTO를 반환해 API가 엔티티에 의존하지 않도록 합니다.

## 관련 이슈
Close #10 

## 변경사항
- UserRestController 변경
  - registerUser에서 UserRegisterResponseDto 반환 
- ProfileRestController 변경
  - getProfile에서 ProfileGetDto 반환 