### PR TITLE
feature: Add simple login logout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
 	implementation 'io.springfox:springfox-swagger2:2.9.2'
 	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
@@ -31,6 +32,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-security-test'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.boot:spring-boot-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 test {

--- a/src/main/java/com/example/medium_clone/SecurityConfig.java
+++ b/src/main/java/com/example/medium_clone/SecurityConfig.java
@@ -15,7 +15,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
                 .csrf().disable()
-                .formLogin();
+                .formLogin()
+                    .usernameParameter("email");
     }
 
     @Bean

--- a/src/main/java/com/example/medium_clone/SecurityConfig.java
+++ b/src/main/java/com/example/medium_clone/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.example.medium_clone;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .formLogin();
+    }
+}

--- a/src/main/java/com/example/medium_clone/SecurityConfig.java
+++ b/src/main/java/com/example/medium_clone/SecurityConfig.java
@@ -14,7 +14,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
+                .csrf().disable().authorizeRequests()
+                .antMatchers("/login").permitAll()
+                .antMatchers("/api/users/register").permitAll()
+                .anyRequest().authenticated()
+                .and()
                 .formLogin()
                     .usernameParameter("email");
     }

--- a/src/main/java/com/example/medium_clone/SecurityConfig.java
+++ b/src/main/java/com/example/medium_clone/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.medium_clone;
 
+import com.example.medium_clone.web.auth.PlainPasswordEncoder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -14,5 +16,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .csrf().disable()
                 .formLogin();
+    }
+
+    @Bean
+    public PlainPasswordEncoder passwordEncoder() {
+        return new PlainPasswordEncoder();
     }
 }

--- a/src/main/java/com/example/medium_clone/application/user/entity/User.java
+++ b/src/main/java/com/example/medium_clone/application/user/entity/User.java
@@ -4,13 +4,16 @@ import com.example.medium_clone.application.common.entity.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
+import java.util.Collection;
 
 @Entity
 @Getter
 @ToString(of = {"id", "email"})
-public class User extends BaseTimeEntity {
+public class User extends BaseTimeEntity implements UserDetails {
 
     @Id @GeneratedValue
     @Column(name = "user_id")
@@ -33,4 +36,38 @@ public class User extends BaseTimeEntity {
         this.profile = profile;
     }
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/example/medium_clone/application/user/repository/UserRepository.java
+++ b/src/main/java/com/example/medium_clone/application/user/repository/UserRepository.java
@@ -2,7 +2,12 @@ package com.example.medium_clone.application.user.repository;
 
 import com.example.medium_clone.application.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(@Param("email") String email);
 
 }

--- a/src/main/java/com/example/medium_clone/application/user/service/UserDetailServiceImpl.java
+++ b/src/main/java/com/example/medium_clone/application/user/service/UserDetailServiceImpl.java
@@ -1,0 +1,21 @@
+package com.example.medium_clone.application.user.service;
+
+import com.example.medium_clone.application.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException(email));
+    }
+
+}

--- a/src/main/java/com/example/medium_clone/web/auth/PlainPasswordEncoder.java
+++ b/src/main/java/com/example/medium_clone/web/auth/PlainPasswordEncoder.java
@@ -1,0 +1,15 @@
+package com.example.medium_clone.web.auth;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class PlainPasswordEncoder implements PasswordEncoder {
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return rawPassword.toString();
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return rawPassword.toString().equals(encodedPassword);
+    }
+}

--- a/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/article/controller/ArticleRestControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ArticleRestController.class)
+@WithMockUser
 class ArticleRestControllerTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
+++ b/src/test/java/com/example/medium_clone/application/user/controller/ProfileRestControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Optional;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProfileRestController.class)
+@WithMockUser
 class ProfileRestControllerTest {
 
     @Autowired MockMvc mockMvc;


### PR DESCRIPTION
<!---
<규칙>
- 목적과 변경사항은 반드시 적는다.
-->

## 목적
- 로그인, 로그아웃으로 인증을 할 수 있도록 합니다.

## 관련 이슈
- Close #47 
- #46 

## 변경사항
- 패키지
  - spring-boot-starter-security 추가
- User 엔티티 변경
  - UserDetails 구현
    - 일단 authorities 무시
    - username에서 email 반환
      - 원래는 profile의 username을 이용하려고 했으나 lazy loading으로 인해 에러가 발생해 변경했습니다. 
    - lock, expired 모두 무시하고 항상 true 반환  
- UserRepository 변경
  - findByEmail 추가
- UserDetailServiceImpl 추가
  - UserDetailsService 구현
  - 유저가 존재하는지 확인하는 `loadUserByUsername` 구현 
- PlainPasswordEncode 추가
  - 현재 패스워드 인코딩이 되지 않은채 저장돼 인코딩을 하지 않는 인코더 추가 
- SecurityConfig 추가
  - 로그인, 유저 등록 path를 제외한 나머지 path는 모두 인증이 필요하도록 만듦 
- 테스트
  - 컨트롤러 테스트에서 인증 때문에 실패하므로 mock user를 사용하도록 수정했습니다. 

## 참고
- https://mangkyu.tistory.com/77
- https://programmer93.tistory.com/68
- https://tecoble.techcourse.co.kr/post/2020-09-30-spring-security-test/
